### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ defmodule YourProject.HookHandler do
   @impl true
   def on_boot do
     # read some parameters from your env config
-    env_config = Application.get_env(:your_porject, __MODULE__)
+    env_config = Application.get_env(:your_project, __MODULE__)
     # delete the webhook and set it again
     {:ok, true} = Telegex.delete_webhook()
     # set the webhook (url is required)
@@ -254,7 +254,7 @@ You can create handlers for two modes and determine which one to start based on 
 
 ```elixir
 updates_handler =
-  if Application.get_env(:your_porject, :work_mode) == :webhook do
+  if Application.get_env(:your_project, :work_mode) == :webhook do
     YourProject.HookHandler
   else
     YourProject.PollingHandler


### PR DESCRIPTION
Hi @Hentioe!
I am reading a lot the documentation for Telegex and I find one typo in the examples you provided for the handlers (`:your_porject` instead of `:your_project`).

I open this draft PR to fix them, but I will commit any other fixes. Of course, if you prefer to just take where are the fixes and not have a PR, just tell me without problems and I just report you in an issue.