### PR TITLE
feat: support custom telegram bot api

### DIFF
--- a/lib/telegex/caller/adapter.ex
+++ b/lib/telegex/caller/adapter.ex
@@ -25,7 +25,7 @@ defmodule Telegex.Caller.Adapter do
   def impl, do: Module.concat(__MODULE__, config(:adapter))
 
   @spec build_url(String.t()) :: String.t()
-  def build_url(method), do: "https://api.telegram.org/bot#{Telegex.Instance.token()}/#{method}"
+  def build_url(method), do: "#{Telegex.Instance.api()}#{Telegex.Instance.token()}/#{method}"
 
   @spec options :: keyword
   def options, do: config(:options)

--- a/lib/telegex/instance.ex
+++ b/lib/telegex/instance.ex
@@ -13,7 +13,7 @@ defmodule Telegex.Instance do
   def token, do: Application.get_env(:telegex, :token)
 
   @spec api() :: String.t
-  def api, do: Application.get_env(:telegex, :api)
+  def api, do: Application.get_env(:telegex, :api, "https://api.telegram.org/bot")
 
   @impl true
   def init(state) do

--- a/lib/telegex/instance.ex
+++ b/lib/telegex/instance.ex
@@ -12,6 +12,9 @@ defmodule Telegex.Instance do
   @spec token() :: String.t()
   def token, do: Application.get_env(:telegex, :token)
 
+  @spec api() :: String.t
+  def api, do: Application.get_env(:telegex, :api)
+
   @impl true
   def init(state) do
     {:ok, state}


### PR DESCRIPTION
in some cases, we need to use custom telegram apis.

ref: https://core.telegram.org/bots/api#using-a-local-bot-api-server