### PR TITLE
use `with` to implement pipeline macro

### DIFF
--- a/lib/telegex/chain/handler.ex
+++ b/lib/telegex/chain/handler.ex
@@ -1,19 +1,6 @@
 defmodule Telegex.Chain.Handler do
   @moduledoc false
 
-  # 以管道的形式调用多个 chain
-  def call(chains, update, context \\ %{}) when is_list(chains) and is_map(context) do
-    call_chain = fn chain, {_state, context} ->
-      case chain.call(update, context) do
-        {:ok, context} -> {:cont, {:ok, context}}
-        {:stop, context} -> {:halt, {:stop, context}}
-        {:done, context} -> {:halt, {:done, context}}
-      end
-    end
-
-    Enum.reduce_while(chains, {:init, context}, call_chain)
-  end
-
   defmacro __using__(_) do
     quote do
       import unquote(__MODULE__), only: [pipeline: 1]
@@ -23,14 +10,23 @@ defmodule Telegex.Chain.Handler do
   end
 
   defmacro pipeline(modules) do
-    quote do
-      def __chains__ do
-        unquote(modules)
-      end
+    clauses =
+      modules
+      |> Enum.map(
+        &quote do
+          {:ok, context} <- unquote(&1).call(update, context)
+        end
+      )
+      |> Enum.to_list
 
+    quote do
       @spec call(Telegex.Type.Update.t(), Telegex.Chain.context()) :: Telegex.Chain.result()
       def call(update, context) do
-        unquote(__MODULE__).call(__MODULE__.__chains__(), update, context)
+        with unquote_splicing(clauses) do
+          {:ok, context}
+        else
+          err -> err
+        end
       end
     end
   end


### PR DESCRIPTION
This will move the verification into the compilation instead of runtime exception.